### PR TITLE
Ubuntu Repo fix and add initial 26.04 LTS 

### DIFF
--- a/edge/RC8/1_preflight.sh
+++ b/edge/RC8/1_preflight.sh
@@ -60,11 +60,13 @@ echo "Ubuntu release:"
 echo "1) noble    (24.04 LTS, recommended)"
 echo "2) oracular (24.10)"
 echo "3) plucky   (25.04)"
-read -p "Choice [1-3, default 1]: " REL_CHOICE
+echo "4) resolute (26.04 LTS Beta)"
+read -p "Choice [1-4, default 1]: " REL_CHOICE
 REL_CHOICE=${REL_CHOICE:-1}
 case $REL_CHOICE in
     2) UBUNTU_RELEASE="oracular" ;;
     3) UBUNTU_RELEASE="plucky"   ;;
+    4) UBUNTU_RELEASE="resolute" ;;
     *) UBUNTU_RELEASE="noble"    ;;
 esac
 echo ">>> Using Ubuntu release: $UBUNTU_RELEASE"

--- a/edge/RC8/3_rootfs_cooker.sh
+++ b/edge/RC8/3_rootfs_cooker.sh
@@ -69,6 +69,7 @@ cat > /etc/apt/sources.list << APT_EOF
 deb http://ports.ubuntu.com/ubuntu-ports/ ${UBUNTU_RELEASE} main restricted universe multiverse
 deb http://ports.ubuntu.com/ubuntu-ports/ ${UBUNTU_RELEASE}-updates main restricted universe multiverse
 deb http://ports.ubuntu.com/ubuntu-ports/ ${UBUNTU_RELEASE}-security main restricted universe multiverse
+deb http://ports.ubuntu.com/ubuntu-ports/ ${UBUNTU_RELEASE}-backports main restricted universe multiverse
 APT_EOF
 
 # Update base repos and install curl + ca-certificates first


### PR DESCRIPTION
right now, we need to build against ubuntu 24.10 or LATER due to dependancy issues from the Ubuntu/Debian repo mix up
(with these fixes, it should also restore the ability to install Phosh, next release may be Phosh but most likely will be Ubuntu-Desktop-Minimal)